### PR TITLE
Modified ResetHistograms to use the already-calculated

### DIFF
--- a/T41EEE/CWProcessing.cpp
+++ b/T41EEE/CWProcessing.cpp
@@ -390,11 +390,9 @@ void MorseCharacterDisplay(char currentLetter) {
     void
 *****/
 void ResetHistograms() {
-  gapAtom = 80;
-  ditLength = 80;  // Start with 15wpm ditLength
-  gapChar = 240;
-  dahLength = 240;
-  thresholdGeometricMean = 160;  // Use simple mean for starters so we don't have 0
+  gapAtom = ditLength = transmitDitLength;
+  gapChar = dahLength = transmitDitLength * 3;
+  thresholdGeometricMean = (ditLength + dahLength) / 2;  // Use simple mean for starters so we don't have 0
   aveDitLength = ditLength;
   aveDahLength = dahLength;
   valRef1 = 0;
@@ -402,8 +400,6 @@ void ResetHistograms() {
   // Clear graph arrays
   memset(signalHistogram, 0, HISTOGRAM_ELEMENTS * sizeof(uint32_t));
   memset(gapHistogram, 0, HISTOGRAM_ELEMENTS * sizeof(uint32_t));
-  EEPROMData.currentWPM = 1200 / ditLength;
-  UpdateWPMField();
 }
 
 


### PR DESCRIPTION
transmitDitLength, and not to reset the current keyer speed to 15wpm. Since the keyer speed is not being modified, there is also no reason to call UpdateWPMField.

This behavior is consistent with the purpose comment for ResetHistograms, and closer to the V049.2 behavior, which did not update EEPROMData.currentWPM.